### PR TITLE
Scan tag clinicalnote

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,43 @@ anonymised_dcm.save_as('/path/to/some/dicom_anon.dcm')
 
 ```
 
+## De-identifying a file and generating its HTML report
+
+`html_report` builds a self-contained HTML report describing what was removed:
+the names of the scrubbed header fields, plus a before/after diff of every long
+free-text field (e.g. a radiology report). The snapshot must be taken **before**
+`anonymise_image`, which mutates the dataset in place.
+
+```python
+import pydicom as dicom
+from phi_finder.dicom_tools import anonymise_dicom, html_report
+
+path = "/path/to/some/dicom.dcm"
+dcm = dicom.dcmread(path)
+
+# Record the free-text fields before they are redacted.
+note_snapshot = html_report.snapshot_long_text(dcm)
+
+anonymised_dcm = anonymise_dicom.anonymise_image(dcm)
+anonymised_dcm.save_as('/path/to/some/dicom_anon.dcm')
+
+report = html_report.build_html_report(
+    html_report.read_flagged_headers(anonymised_dcm),
+    n_images=1,
+    session_id="my-session",
+    use_case="Standard",
+    note_diffs=html_report.collect_note_diffs(note_snapshot, anonymised_dcm),
+)
+with open('/path/to/some/deidentification_report.html', 'w', encoding='utf-8') as f:
+    f.write(report)
+```
+
+`note_diffs` is optional — omit it (along with `snapshot_long_text` /
+`collect_note_diffs`) to get a report that lists only the names of the scrubbed
+header fields.
+
+> **Warning:** a report built with `note_diffs` reproduces the *original* clinical-note text, since the struck-through spans are the PHI itself.
+
 ## De-identifying headers with the DICOM PS3.15 profile
 
 The `use_case` argument selects how header values are de-identified:

--- a/phi_finder/dicom_tools/anonymise_dicom.py
+++ b/phi_finder/dicom_tools/anonymise_dicom.py
@@ -22,6 +22,11 @@ from phi_finder.dicom_tools import ps3_15
 logging.getLogger("presidio-analyzer").setLevel(logging.ERROR)
 logger = logging.getLogger(__name__)
 
+# Provenance stamped on each flagged-header record, so the de-identification
+# report can separate headers whose value was read and scrubbed by the NER
+# models from those the PS3.15 action map handled (see ps3_15.SOURCE_PS3_15).
+SOURCE_NER = "ner"
+
 
 def destroy_pixels(ds: dicom.dataset.FileDataset) -> dicom.dataset.FileDataset:
     """It sets all pixel values to 0.
@@ -460,7 +465,7 @@ def _anonymise_ds(ds: dicom.dataset.Dataset,
             continue
         if elem.VR == "PN" or elem.tag == (0x0010, 0x0010):
             ds[elem.tag].value = PersonName("XXXX")
-            anonymised_headers.append({"tag": str(elem.tag), "name": elem.name})
+            anonymised_headers.append({"tag": str(elem.tag), "name": elem.name, "source": SOURCE_NER})
         elif elem.tag == (0x0010, 0x0040):  # Sex unchanged.
             continue
         elif elem.tag == (0x0010, 0x0030):  # Birthdate
@@ -477,12 +482,12 @@ def _anonymise_ds(ds: dicom.dataset.Dataset,
             # Fail-safe: if the format is unrecognised, scrub the value so the
             # original birthdate never survives in the dataset.
             ds[elem.tag].value = f"{year:04d}0101" if year is not None else "19000101"
-            anonymised_headers.append({"tag": str(elem.tag), "name": elem.name})
+            anonymised_headers.append({"tag": str(elem.tag), "name": elem.name, "source": SOURCE_NER})
         elif elem.VR == "AS":
             if str(elem.value).strip() in ("", "000Y"):
                 continue
             ds[elem.tag].value = "000Y"
-            anonymised_headers.append({"tag": str(elem.tag), "name": elem.name})
+            anonymised_headers.append({"tag": str(elem.tag), "name": elem.name, "source": SOURCE_NER})
         elif elem.VR in [
             "LO",  # Long String
             "LT",  # Long Text
@@ -516,7 +521,7 @@ def _anonymise_ds(ds: dicom.dataset.Dataset,
                         redacted = _anonymise_with_transformer(gliner_pii, redacted, threshold=score_threshold, return_entities=False)
                     new_values.append(redacted)
                 if new_values != values:
-                    anonymised_headers.append({"tag": str(elem.tag), "name": elem.name})
+                    anonymised_headers.append({"tag": str(elem.tag), "name": elem.name, "source": SOURCE_NER})
                 if is_multi:
                     ds[elem.tag].value = dicom.multival.MultiValue(str, new_values)
                 else:
@@ -531,7 +536,7 @@ def _anonymise_ds(ds: dicom.dataset.Dataset,
                     ds[elem.tag].value = ""
                 except Exception:
                     del ds[elem.tag]
-                anonymised_headers.append({"tag": str(elem.tag), "name": elem.name})
+                anonymised_headers.append({"tag": str(elem.tag), "name": elem.name, "source": SOURCE_NER})
 
 
 def anonymise_image(ds: dicom.dataset.FileDataset,

--- a/phi_finder/dicom_tools/anonymise_dicom.py
+++ b/phi_finder/dicom_tools/anonymise_dicom.py
@@ -334,9 +334,6 @@ def _anonymise_with_transformer(model: UniEncoderSpanGLiNER,
                                 return_entities: bool=False) -> str:
     """Anonymises text using a specified named entity recognition (NER) pipeline.
 
-    This function processes the input text through the provided NER pipeline,
-    replacing recognised entities of type "PER", "LOC", and "ORG" with the placeholder "[XXXX]".
-
     Parameters
     ----------
     model : Gliner's UniEncoderSpanGLiNER
@@ -415,46 +412,8 @@ _NER_SCANNED_TAGS = frozenset({
 })
 
 
-# Analysers that anonymise_image builds for itself (i.e. the caller passed
-# none) are cached. A PS3.15 run only needs one when it meets a file carrying a
-# free-text attribute, and rebuilding the spaCy pipeline for every such file
-# would dominate the runtime of a report-heavy session.
-_ANALYSER_CACHE: dict[float, AnalyzerEngine] = {}
-
-
-def _lazy_presidio_analyser(score_threshold: float) -> AnalyzerEngine:
-    """Returns a shared Presidio analyser, building it on first use.
-
-    Parameters
-    ----------
-    score_threshold : float
-        The score threshold the analyser's custom recognisers are built with.
-
-    Returns
-    -------
-    AnalyzerEngine
-        The cached analyser for this threshold.
-    """
-    if score_threshold not in _ANALYSER_CACHE:
-        _ANALYSER_CACHE[score_threshold] = _build_presidio_analyser(score_threshold)
-    return _ANALYSER_CACHE[score_threshold]
-
-
 def _contains_ner_scanned_tag(ds: dicom.dataset.Dataset) -> bool:
-    """Reports whether a dataset holds any of the tags in ``_NER_SCANNED_TAGS``.
-
-    Sequences are searched too, so a Text Value nested in a content item counts.
-    Used to decide whether a PS3.15 run needs the NER engines at all.
-
-    Parameters
-    ----------
-    ds : pydicom.dataset.Dataset
-        The dataset to search.
-
-    Returns
-    -------
-    bool
-        True if at least one NER-scanned attribute is present.
+    """Checks if the dicom has any of the tags in ``_NER_SCANNED_TAGS``.
     """
     for elem in ds:
         if elem.tag in _NER_SCANNED_TAGS:
@@ -479,8 +438,7 @@ def _anonymise_ds(ds: dicom.dataset.Dataset,
     When ``private_only`` is True, only private attributes and the free-text
     attributes in ``_NER_SCANNED_TAGS`` have their values scanned/redacted; the
     remaining standard attributes are left untouched (the caller has already
-    de-identified them, e.g. via the PS3.15 Basic Profile). Sequences are still
-    recursed into so attributes nested inside them are reached.
+    de-identified them, e.g. via the PS3.15 Basic Profile).
 
     Private creator elements are never scrubbed: 
     the creator string identifies the block's owner; redacting it'd corrupt the creator-to-data mapping of every element in the block.
@@ -568,8 +526,7 @@ def _anonymise_ds(ds: dicom.dataset.Dataset,
                 else:
                     ds[elem.tag].value = new_values[0]
             except Exception as e:
-                # Fail closed: a value that could not be analysed may still
-                # contain PHI, so blank it rather than leave the original.
+                # A value that couldn't be analysed may contain PHI, so blank it.
                 logger.error(
                     "Failed to redact %s (%s), blanking it. %s: %s",
                     elem.tag, elem.name, type(e).__name__, e,
@@ -611,7 +568,7 @@ def anonymise_image(ds: dicom.dataset.FileDataset,
     gliner_pii: UniEncoderSpanGLiNER, optional (default False)
         If set, the model will be used for anonymisation on top of Presidio's output.
 
-    use_case : str, optional (default 'Standard')
+    use_case : str, optional (default 'dicom_retain_patient_scan_private')
         * PS3.15 (alias 'dicom_default'): headers are de-identified with the
         DICOM PS3.15 Annex E Basic Application Level Confidentiality Profile;
         Presidio and GLiNER are not used on the headers.
@@ -622,9 +579,7 @@ def anonymise_image(ds: dicom.dataset.FileDataset,
         the matching PS3.15 variant for the standard headers, but private
         attributes are kept and scanned with the Presidio/GLiNER pipeline
         instead of being removed.
-        * Any other value (e.g. 'Standard', 'Aggressive'): headers are scanned with the
-        Presidio NER pipeline (plus GLiNER when gliner_pii is given) and
-        redacted.
+        * Any other value: use Presidio (plus GLiNER when gliner_pii is given).
 
     Returns
     -------
@@ -640,14 +595,10 @@ def anonymise_image(ds: dicom.dataset.FileDataset,
 
     ps3_15_mode = ps3_15.is_ps3_15_use_case(use_case)
     scan_private = ps3_15.scan_private_headers(use_case)
-    # The NER engines are needed for the full pipeline, for the private-header
-    # scan that the "..._scan_private" PS3.15 variants run on top of the profile,
-    # and for the free-text attributes the profile has no action for (only built
-    # when the dataset actually carries one, so plain PS3.15 stays cheap).
     ner_scanned_tags_present = ps3_15_mode and _contains_ner_scanned_tag(ds)
     if not ps3_15_mode or scan_private or ner_scanned_tags_present:
         if analyser is None:
-            analyser = _lazy_presidio_analyser(score_threshold)
+            analyser = _build_presidio_analyser(score_threshold)
         if anonymizer is None:
             anonymizer = AnonymizerEngine()
     if image_redactor is not None:
@@ -662,10 +613,6 @@ def anonymise_image(ds: dicom.dataset.FileDataset,
             scan_private=scan_private,
         )
         if scan_private or ner_scanned_tags_present:
-            # Attributes the profile kept — private ones in the "..._scan_private"
-            # variants, plus the free-text ones Table E.1-1 has no action for —
-            # have their PHI scrubbed by the NER pipeline instead of being
-            # removed outright.
             _anonymise_ds(ds, analyser, anonymizer, score_threshold,
                           gliner_pii, use_case, anonymised_headers,
                           private_only=True)

--- a/phi_finder/dicom_tools/anonymise_dicom.py
+++ b/phi_finder/dicom_tools/anonymise_dicom.py
@@ -63,7 +63,7 @@ def destroy_pixels(ds: dicom.dataset.FileDataset) -> dicom.dataset.FileDataset:
 
 
 def _build_presidio_analyser(score_threshold: float=0.5,
-                             spacy_model_name: str="en_core_web_md") -> AnalyzerEngine:
+                             spacy_model_name: str="en_core_web_lg") -> AnalyzerEngine:
     """Builds and configures a Presidio analyser engine for named entity recognition.
 
     Parameters
@@ -72,7 +72,7 @@ def _build_presidio_analyser(score_threshold: float=0.5,
         The score threshold for entity recognition. Entities with a score below this
         threshold will not be considered for anonymisation. Default is 0.5.
     spacy_model_name : str, optional
-        The name of the SpaCy model to use for NLP processing. Default is "en_core_web_md".
+        The name of the SpaCy model to use for NLP processing. Default is "en_core_web_lg".
         Other options include "en_core_web_sm" and "en_core_web_lg".
         
     Returns
@@ -319,12 +319,12 @@ def _build_presidio_analyser(score_threshold: float=0.5,
 
 def _build_transformer() -> UniEncoderSpanGLiNER:
     model = GLiNER.from_pretrained("nvidia/gliner-pii")#, max_length=384)
-    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device('cpu')#torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     model.to(device)
     model.eval()
-    if torch.cuda.is_available():
-        model.compile()
-        torch.set_float32_matmul_precision('high')
+    #if torch.cuda.is_available():
+    #    model.compile()
+    #    torch.set_float32_matmul_precision('high')
     return model
 
 
@@ -357,11 +357,7 @@ def _anonymise_with_transformer(model: UniEncoderSpanGLiNER,
         "age", "profession", "gender", "name",
         "sex", "language", "ethnicity",
         "country", "city", "state", "suburb",
-        "location", "person", "organization",
-        "phone number", "address", "passport number",
-        "email", "social security number", "health insurance id number",
-        "date of birth", "mobile phone number",
-        "health insurance number",
+        "location", "person", "organization"
     ]
     # merged collapses overlapping entity spans into non-overlapping
     # ones so the slice-replacement at the end doesn't
@@ -544,7 +540,9 @@ def anonymise_image(ds: dicom.dataset.FileDataset,
                     image_redactor: DicomImageRedactorEngine = None,
                     score_threshold: float=0.5,
                     gliner_pii: UniEncoderSpanGLiNER=None,
-                    use_case: str='Standard') -> dicom.dataset.FileDataset:
+                    use_case: str='Standard',
+                    spacy_model_name: str="en_core_web_lg",
+                    ) -> dicom.dataset.FileDataset:
     """Anonymises a DICOM image by redacting personal information.
 
     Parameters
@@ -581,6 +579,9 @@ def anonymise_image(ds: dicom.dataset.FileDataset,
         instead of being removed.
         * Any other value: use Presidio (plus GLiNER when gliner_pii is given).
 
+    spacy_model_name : str, optional (default "en_core_web_lg")
+        Only used when ``analyser`` is not supplied and one has to be built here.
+
     Returns
     -------
     pydicom.dataset.FileDataset
@@ -598,7 +599,7 @@ def anonymise_image(ds: dicom.dataset.FileDataset,
     ner_scanned_tags_present = ps3_15_mode and _contains_ner_scanned_tag(ds)
     if not ps3_15_mode or scan_private or ner_scanned_tags_present:
         if analyser is None:
-            analyser = _build_presidio_analyser(score_threshold)
+            analyser = _build_presidio_analyser(score_threshold, spacy_model_name)
         if anonymizer is None:
             anonymizer = AnonymizerEngine()
     if image_redactor is not None:

--- a/phi_finder/dicom_tools/anonymise_dicom.py
+++ b/phi_finder/dicom_tools/anonymise_dicom.py
@@ -408,6 +408,63 @@ _STRUCTURAL_TAGS = frozenset({
     Tag(0x0028, 0x0004),  # Photometric Interpretation
 })
 
+# Standard headers that PS3.15 Table E.1-1 gives no action to, 
+# but they can hold long texts, so the NER models scan them.
+_NER_SCANNED_TAGS = frozenset({
+    Tag(0x0040, 0xA160),  # Text Value (SR Document Content)
+})
+
+
+# Analysers that anonymise_image builds for itself (i.e. the caller passed
+# none) are cached. A PS3.15 run only needs one when it meets a file carrying a
+# free-text attribute, and rebuilding the spaCy pipeline for every such file
+# would dominate the runtime of a report-heavy session.
+_ANALYSER_CACHE: dict[float, AnalyzerEngine] = {}
+
+
+def _lazy_presidio_analyser(score_threshold: float) -> AnalyzerEngine:
+    """Returns a shared Presidio analyser, building it on first use.
+
+    Parameters
+    ----------
+    score_threshold : float
+        The score threshold the analyser's custom recognisers are built with.
+
+    Returns
+    -------
+    AnalyzerEngine
+        The cached analyser for this threshold.
+    """
+    if score_threshold not in _ANALYSER_CACHE:
+        _ANALYSER_CACHE[score_threshold] = _build_presidio_analyser(score_threshold)
+    return _ANALYSER_CACHE[score_threshold]
+
+
+def _contains_ner_scanned_tag(ds: dicom.dataset.Dataset) -> bool:
+    """Reports whether a dataset holds any of the tags in ``_NER_SCANNED_TAGS``.
+
+    Sequences are searched too, so a Text Value nested in a content item counts.
+    Used to decide whether a PS3.15 run needs the NER engines at all.
+
+    Parameters
+    ----------
+    ds : pydicom.dataset.Dataset
+        The dataset to search.
+
+    Returns
+    -------
+    bool
+        True if at least one NER-scanned attribute is present.
+    """
+    for elem in ds:
+        if elem.tag in _NER_SCANNED_TAGS:
+            return True
+        if elem.VR == "SQ":
+            for sub_ds in elem.value:
+                if isinstance(sub_ds, dicom.dataset.Dataset) and _contains_ner_scanned_tag(sub_ds):
+                    return True
+    return False
+
 
 def _anonymise_ds(ds: dicom.dataset.Dataset,
                   analyser: AnalyzerEngine,
@@ -419,10 +476,11 @@ def _anonymise_ds(ds: dicom.dataset.Dataset,
                   private_only: bool = False) -> None:
     """Recursively anonymises all elements in a DICOM dataset in-place.
 
-    When ``private_only`` is True, only private attributes have their values
-    scanned/redacted; standard attributes are left untouched (the caller has
-    already de-identified them, e.g. via the PS3.15 Basic Profile). Sequences
-    are still recursed into so private attributes nested inside them are reached.
+    When ``private_only`` is True, only private attributes and the free-text
+    attributes in ``_NER_SCANNED_TAGS`` have their values scanned/redacted; the
+    remaining standard attributes are left untouched (the caller has already
+    de-identified them, e.g. via the PS3.15 Basic Profile). Sequences are still
+    recursed into so attributes nested inside them are reached.
 
     Private creator elements are never scrubbed: 
     the creator string identifies the block's owner; redacting it'd corrupt the creator-to-data mapping of every element in the block.
@@ -444,9 +502,7 @@ def _anonymise_ds(ds: dicom.dataset.Dataset,
             continue
         if elem.tag.is_private_creator:
             continue  # Private creators ("SIEMENS CSA HEADER") never touched.
-        if private_only and not elem.tag.is_private:
-            # Only scrub private data elements; leave standard attributes
-            # untouched (the caller already handled them).
+        if private_only and not elem.tag.is_private and elem.tag not in _NER_SCANNED_TAGS:
             continue
         if elem.VR == "PN" or elem.tag == (0x0010, 0x0010):
             ds[elem.tag].value = PersonName("XXXX")
@@ -584,11 +640,14 @@ def anonymise_image(ds: dicom.dataset.FileDataset,
 
     ps3_15_mode = ps3_15.is_ps3_15_use_case(use_case)
     scan_private = ps3_15.scan_private_headers(use_case)
-    # The NER engines are needed for the full pipeline and for the private-header
-    # scan that the "..._scan_private" PS3.15 variants run on top of the profile.
-    if not ps3_15_mode or scan_private:
+    # The NER engines are needed for the full pipeline, for the private-header
+    # scan that the "..._scan_private" PS3.15 variants run on top of the profile,
+    # and for the free-text attributes the profile has no action for (only built
+    # when the dataset actually carries one, so plain PS3.15 stays cheap).
+    ner_scanned_tags_present = ps3_15_mode and _contains_ner_scanned_tag(ds)
+    if not ps3_15_mode or scan_private or ner_scanned_tags_present:
         if analyser is None:
-            analyser = _build_presidio_analyser(score_threshold)
+            analyser = _lazy_presidio_analyser(score_threshold)
         if anonymizer is None:
             anonymizer = AnonymizerEngine()
     if image_redactor is not None:
@@ -602,9 +661,11 @@ def anonymise_image(ds: dicom.dataset.FileDataset,
             retain_patient_characteristics=ps3_15.retain_patient_characteristics(use_case),
             scan_private=scan_private,
         )
-        if scan_private:
-            # Private attributes were kept by the profile; scrub PHI from their
-            # values with the NER pipeline instead of removing them outright.
+        if scan_private or ner_scanned_tags_present:
+            # Attributes the profile kept — private ones in the "..._scan_private"
+            # variants, plus the free-text ones Table E.1-1 has no action for —
+            # have their PHI scrubbed by the NER pipeline instead of being
+            # removed outright.
             _anonymise_ds(ds, analyser, anonymizer, score_threshold,
                           gliner_pii, use_case, anonymised_headers,
                           private_only=True)

--- a/phi_finder/dicom_tools/html_report.py
+++ b/phi_finder/dicom_tools/html_report.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 
 import pydicom
+from pydicom.datadict import dictionary_description
 from fileformats.generic import File
 from frametree.core.entry import DataEntry
 from frametree.core.row import DataRow
@@ -63,6 +64,53 @@ def _walk_note_text(ds: pydicom.dataset.Dataset,
         yield prefix + (elem.tag,), elem.name, value
 
 
+def _tag_name(tag: pydicom.tag.Tag) -> str:
+    """Returns a tag's human-readable name, falling back to its numeric form.
+
+    Parameters
+    ----------
+    tag : pydicom.tag.Tag
+        The tag to describe.
+
+    Returns
+    -------
+    str
+        The DICOM dictionary description, or ``str(tag)`` for private and
+        unknown tags that have no entry.
+    """
+    try:
+        return dictionary_description(tag)
+    except (KeyError, ValueError):
+        return str(tag)
+
+
+def _path_label(path: tuple, leaf_name: str = "") -> str:
+    """Renders an element ``path`` as a readable location.
+
+    A note nested inside sequences is reported as, e.g., ``"Content Sequence
+    [4] > Content Sequence [0] > Text Value"``, so two same-named elements in
+    different places in the tree can be told apart.
+
+    Parameters
+    ----------
+    path : tuple
+        An element path as produced by ``_walk_note_text``: alternating
+        sequence tag and item index, ending with the element's own tag.
+    leaf_name : str, optional
+        Name to use for the final component. Defaults to looking the tag up.
+
+    Returns
+    -------
+    str
+        The formatted location.
+    """
+    parts = [
+        f"{_tag_name(path[i])} [{path[i + 1]}]" for i in range(0, len(path) - 1, 2)
+    ]
+    parts.append(leaf_name or _tag_name(path[-1]))
+    return " > ".join(parts)
+
+
 def snapshot_long_text(ds: pydicom.dataset.Dataset) -> dict:
     """Records the free-text fields of a dataset before it is anonymised.
 
@@ -97,7 +145,13 @@ def collect_note_diffs(snapshot: dict, ds: pydicom.dataset.Dataset) -> list[dict
     Returns
     -------
     list of dict
-        One ``{"name", "original", "redacted"}`` entry per changed note. The
+        One ``{"name", "location", "original", "redacted", "removed"}`` entry
+        per changed note. ``"location"`` is the element's full path through any
+        enclosing sequences, which distinguishes same-named notes in different
+        places in the tree. ``"removed"`` is True when the element is gone from
+        the dataset altogether (e.g. the sequence holding it was emptied by the
+        PS3.15 profile) rather than redacted in place — both leave no text
+        behind, but only the latter means the value itself was scanned. The
         ``"original"`` value contains the un-redacted PHI, so callers must
         treat the result as sensitive.
     """
@@ -106,10 +160,17 @@ def collect_note_diffs(snapshot: dict, ds: pydicom.dataset.Dataset) -> list[dict
     for path, (name, original) in snapshot.items():
         if len(original) < _CLINICAL_NOTE_MIN_LENGTH:
             continue
+        removed = path not in current
         redacted = current.get(path, "")
         if redacted == original:
             continue
-        diffs.append({"name": name, "original": original, "redacted": redacted})
+        diffs.append({
+            "name": name,
+            "location": _path_label(path, name),
+            "original": original,
+            "redacted": redacted,
+            "removed": removed,
+        })
     return diffs
 
 
@@ -210,8 +271,10 @@ def build_html_report(flagged_headers: list[dict],
         value to make the output deterministic (e.g. in tests).
     note_diffs : list of dict, optional
         Clinical-note diffs accumulated over the session, as produced by
-        ``collect_note_diffs``. Each entry needs ``"name"``, ``"original"``
-        and ``"redacted"`` keys. Identical diffs (same note repeated across
+        ``collect_note_diffs``. Each entry needs ``"name"``, ``"original"`` and
+        ``"redacted"`` keys, and may carry ``"location"`` (used in place of the
+        name as the heading) and ``"removed"`` (rendered as a deleted rather
+        than a redacted field). Identical diffs (same note repeated across
         slices) are de-duplicated. Defaults to no diffs.
 
     Returns
@@ -256,27 +319,38 @@ def build_html_report(flagged_headers: list[dict],
         )
 
     # De-duplicate identical note diffs (the same report repeats across slices).
-    seen: set[tuple[str, str, str]] = set()
+    seen: set[tuple[str, str, str, bool]] = set()
     diff_blocks = []
     for diff in note_diffs or []:
         original = diff.get("original", "")
         redacted = diff.get("redacted", "")
         name = (diff.get("name") or "").strip()
-        key = (name, original, redacted)
+        location = (diff.get("location") or "").strip() or name
+        removed = bool(diff.get("removed"))
+        key = (location, original, redacted, removed)
         if key in seen:
             continue
         seen.add(key)
-        heading = esc(name) if name else "Clinical note"
-        diff_blocks.append(
-            f"    <h3>{heading}</h3>\n"
-            f'    <p class="diff">{_render_text_diff(original, redacted)}</p>'
-        )
+        heading = esc(location) if location else "Clinical note"
+        if removed:
+            # The element is gone, so there is nothing to diff against: show
+            # the whole original as deleted and say so, rather than letting it
+            # look like a thorough in-place redaction.
+            badge = '<span class="badge badge-removed">removed entirely</span>'
+            body = f'    <p class="diff diff-removed"><del>{esc(original)}</del></p>'
+        else:
+            badge = '<span class="badge badge-redacted">redacted in place</span>'
+            body = f'    <p class="diff">{_render_text_diff(original, redacted)}</p>'
+        diff_blocks.append(f"    <h3>{heading} {badge}</h3>\n{body}")
 
     if diff_blocks:
         diff_intro = (
             "    <p>The following free-text note(s) contained personal or "
-            "health information. Text that was removed is struck through; the "
-            "replacement is underlined. <strong>This section reproduces the "
+            "health information. A field marked <em>redacted in place</em> is "
+            "still in the image, with the removed text struck through and its "
+            "replacement underlined; a field marked <em>removed entirely</em> "
+            "was deleted from the image altogether, so its whole original "
+            "value is struck through. <strong>This section reproduces the "
             "original information and must be handled accordingly.</strong></p>"
         )
         diff_section = "\n  <h2>Clinical notes</h2>\n" + diff_intro + "\n" + "\n".join(diff_blocks)
@@ -305,6 +379,12 @@ def build_html_report(flagged_headers: list[dict],
     li {{ margin: 0.15rem 0; }}
     .diff {{ white-space: pre-wrap; background: #fafafa; border: 1px solid #eee;
              border-radius: 6px; padding: 0.75rem 1rem; }}
+    .diff-removed {{ background: #fff7f7; border-color: #f0cdcd; }}
+    .badge {{ font-size: 0.7rem; font-weight: normal; text-transform: uppercase;
+              letter-spacing: 0.03em; padding: 0.1rem 0.4rem; border-radius: 3px;
+              vertical-align: middle; white-space: nowrap; }}
+    .badge-redacted {{ background: #e6f0e6; color: #060; border: 1px solid #cde0cd; }}
+    .badge-removed {{ background: #fde8e8; color: #900; border: 1px solid #f0cdcd; }}
     del {{ background: #fdd; color: #900; }}
     ins {{ background: #dfd; color: #060; text-decoration: none; }}
     footer {{ margin-top: 2rem; font-size: 0.8rem; color: #777; }}

--- a/phi_finder/dicom_tools/html_report.py
+++ b/phi_finder/dicom_tools/html_report.py
@@ -12,6 +12,8 @@ from fileformats.generic import File
 from frametree.core.entry import DataEntry
 from frametree.core.row import DataRow
 
+from phi_finder.dicom_tools import anonymise_dicom, ps3_15
+
 
 # Free-text VRs whose value can hold a clinical note (e.g. radiology report).
 _NOTE_TEXT_VRS = frozenset({"LO", "LT", "SH", "ST", "UC", "UT"})
@@ -19,6 +21,32 @@ _NOTE_TEXT_VRS = frozenset({"LO", "LT", "SH", "ST", "UC", "UT"})
 _CLINICAL_NOTE_MIN_LENGTH = 60
 # phi-finder's own audit element written by anonymise_image; never a note.
 _AUDIT_TAG = 0x02091000
+
+# Header findings are grouped by the "source" each record carries, in this
+# order. Records written before provenance was recorded have no source; they
+# fall into the trailing unlabelled group, which keeps their old rendering.
+_FINDING_SECTIONS: "list[tuple[str, str, str]]" = [
+    (
+        ps3_15.SOURCE_PS3_15,
+        "Removed by the DICOM PS3.15 profile",
+        "These header fields were de-identified by the DICOM PS3.15 Annex E "
+        "Basic Application Level Confidentiality Profile, which prescribes a "
+        "fixed action for each of them regardless of what they contained:",
+    ),
+    (
+        anonymise_dicom.SOURCE_NER,
+        "Found by the text-scanning models",
+        "The value of these header fields was read by phi-finder's "
+        "text-recognition models, which removed the parts that looked like "
+        "personal or health information:",
+    ),
+    (
+        "",
+        "",
+        "phi-finder found and removed the following types of personal or "
+        "health information from the image header fields:",
+    ),
+]
 
 
 def _walk_note_text(ds: pydicom.dataset.Dataset,
@@ -220,8 +248,9 @@ def read_flagged_headers(ds: pydicom.dataset.Dataset) -> list[dict]:
 
     ``anonymise_dicom.anonymise_image`` writes a private audit element at
     ``(0209,1000)`` (VR ``UT``, creator ``"phi-finder"``) holding a JSON list
-    of ``{"tag", "name"}`` dicts, one per header whose value was scrubbed.
-    This reads and parses that element.
+    of ``{"tag", "name", "source"}`` dicts, one per header whose value was
+    scrubbed, where ``"source"`` records what de-identified it. This reads and
+    parses that element.
 
     Parameters
     ----------
@@ -231,7 +260,9 @@ def read_flagged_headers(ds: pydicom.dataset.Dataset) -> list[dict]:
     Returns
     -------
     list of dict
-        One ``{"tag": str, "name": str}`` entry per flagged header. Empty when
+        One ``{"tag": str, "name": str, "source": str}`` entry per flagged
+        header (``"source"`` absent in files anonymised by older
+        versions). Empty when
         the audit tag is absent or unreadable, so callers building a report
         never crash on an un-anonymised or malformed file.
     """
@@ -257,7 +288,11 @@ def build_html_report(flagged_headers: list[dict],
         The flagged headers accumulated over the session, as produced by
         ``read_flagged_headers`` (may contain duplicates across images; they
         are de-duplicated here). Each entry needs a ``"name"`` key; ``"tag"``
-        is used as the de-duplication key when present.
+        is used as the de-duplication key when present, and ``"source"``
+        (``ps3_15.SOURCE_PS3_15`` or ``anonymise_dicom.SOURCE_NER``) selects
+        which findings section it is listed under. Entries with no ``"source"``
+        -- reports rebuilt from files anonymised before provenance was
+        recorded -- are listed together in a single unlabelled section.
     n_images : int
         Number of images (DICOM files) processed in the session, shown in the
         summary line.
@@ -285,15 +320,15 @@ def build_html_report(flagged_headers: list[dict],
     if generated_at is None:
         generated_at = datetime.now()
 
-    # De-duplicate by tag when available (stable identity), else by name.
-    unique: dict[str, str] = {}
+    # Group by what de-identified the header, de-duplicating by tag when
+    # available (stable identity) and else by name, within each group.
+    grouped: dict[str, dict[str, str]] = {}
     for header in flagged_headers:
         name = (header.get("name") or "").strip()
         if not name:
             continue
         key = header.get("tag") or name
-        unique[key] = name
-    names = sorted(set(unique.values()), key=str.casefold)
+        grouped.setdefault(header.get("source") or "", {})[key] = name
 
     def esc(value: object) -> str:
         return html.escape(str(value))
@@ -305,13 +340,17 @@ def build_html_report(flagged_headers: list[dict],
         summary_bits.append(f"method <strong>{esc(use_case)}</strong>")
     summary = " &middot; ".join(summary_bits)
 
-    if names:
-        intro = (
-            "phi-finder found and removed the following types of personal or "
-            "health information from the image header fields:"
-        )
+    finding_blocks = []
+    for source, title, intro in _FINDING_SECTIONS:
+        names = sorted(set(grouped.get(source, {}).values()), key=str.casefold)
+        if not names:
+            continue
         items = "\n".join(f"      <li>{esc(name)}</li>" for name in names)
-        findings = f"    <p>{intro}</p>\n    <ul>\n{items}\n    </ul>"
+        heading = f"  <h2>{esc(title)}</h2>\n" if title else ""
+        finding_blocks.append(f"{heading}    <p>{intro}</p>\n    <ul>\n{items}\n    </ul>")
+
+    if finding_blocks:
+        findings = "\n".join(finding_blocks)
     else:
         findings = (
             "    <p>phi-finder found no personal or health information to "

--- a/phi_finder/dicom_tools/ps3_15.py
+++ b/phi_finder/dicom_tools/ps3_15.py
@@ -27,6 +27,11 @@ from pydicom.uid import generate_uid
 
 logger = logging.getLogger(__name__)
 
+# Provenance stamped on each flagged-header record, so the de-identification
+# report can separate what the profile's fixed action map handled from what the
+# NER models found by reading values (see anonymise_dicom.SOURCE_NER).
+SOURCE_PS3_15 = "ps3.15"
+
 BASIC_PROFILE_ACTIONS: dict[int, str] = {
     0x00001000: "X",  # Affected SOP Instance UID
     0x00001001: "U",  # Requested SOP Instance UID
@@ -908,7 +913,7 @@ def _apply(ds: dicom.dataset.Dataset, anonymised_headers: list,
                     if isinstance(item, dicom.dataset.Dataset):
                         _apply(item, anonymised_headers, retain_patient_characteristics, scan_private)
             continue
-        record = {"tag": str(elem.tag), "name": elem.name}
+        record = {"tag": str(elem.tag), "name": elem.name, "source": SOURCE_PS3_15}
         resolved = _resolve_action(action)
         try:
             if resolved == "X":

--- a/phi_finder/dicom_tools/tests/test_anonymise_dicom.py
+++ b/phi_finder/dicom_tools/tests/test_anonymise_dicom.py
@@ -169,32 +169,44 @@ def test_private_creator_untouched_in_standard_mode():
 
 
 def test_build_engines_plain_ps3_15(monkeypatch):
-    def _fail(*args, **kwargs):
-        raise AssertionError("engine builder should not be called")
+    # Even a plain PS3.15 use case gets the NER engines: the profile has no
+    # action for _NER_SCANNED_TAGS (e.g. SR Text Value), so anonymise_image
+    # scans those in every variant. Building them once here keeps it from
+    # building its own for each file that carries one -- and keeps the caller's
+    # spacy model instead of falling back to the default.
+    analyser_sentinel = object()
+    gliner_sentinel = object()
+    models_built = []
 
-    sentinel = object()
-    monkeypatch.setattr(anonymise_dicom, "_build_presidio_analyser", _fail)
-    monkeypatch.setattr(anonymise_dicom, "_build_transformer", lambda: sentinel)
+    def _record(score_threshold, spacy_model_name):
+        models_built.append(spacy_model_name)
+        return analyser_sentinel
 
-    engines = utils._build_engines(
+    monkeypatch.setattr(anonymise_dicom, "_build_presidio_analyser", _record)
+    monkeypatch.setattr(anonymise_dicom, "_build_transformer", lambda: gliner_sentinel)
+
+    analyser, anonymizer, image_redactor, gliner_pii = utils._build_engines(
         use_case="PS3.15",
         score_threshold=0.5,
-        spacy_model_name="en_core_web_md",
+        spacy_model_name="en_core_web_sm",
         destroy_pixels=True,
         use_transformers=False,
     )
-    assert engines == (None, None, None, None)
+    assert analyser is analyser_sentinel
+    assert anonymizer is not None
+    assert image_redactor is None
+    assert gliner_pii is None
+    assert models_built == ["en_core_web_sm"]  # the caller's model, not the default
 
     # GLiNER is built whenever it was asked for, so the free-text scan gets it.
-    analyser, anonymizer, image_redactor, gliner_pii = utils._build_engines(
+    _, _, _, gliner_pii = utils._build_engines(
         use_case="PS3.15",
         score_threshold=0.5,
         spacy_model_name="en_core_web_md",
         destroy_pixels=True,
         use_transformers=True,
     )
-    assert (analyser, anonymizer, image_redactor) == (None, None, None)
-    assert gliner_pii is sentinel
+    assert gliner_pii is gliner_sentinel
 
 
 def test_structural_cs_values_untouched():

--- a/phi_finder/dicom_tools/tests/test_anonymise_dicom.py
+++ b/phi_finder/dicom_tools/tests/test_anonymise_dicom.py
@@ -130,6 +130,7 @@ def test_age_string_replaced_with_valid_sentinel():
         score_threshold=0.5,
         gliner_pii=None,
         use_case="Standard",
+        spacy_model_name="en_core_web_sm"
     )
     assert anonymised_dataset.PatientAge == "000Y"
     flagged = json.loads(anonymised_dataset[0x0209, 0x1000].value)
@@ -146,6 +147,7 @@ def test_specific_character_set_untouched():
     anonymised_dataset = anonymise_dicom.anonymise_image(
         dataset,
         use_case="Standard",
+        spacy_model_name="en_core_web_sm"
     )
     assert anonymised_dataset.SpecificCharacterSet == "ISO 2022 IR 100"
 
@@ -160,7 +162,7 @@ def test_private_creator_untouched_in_standard_mode():
     priv_tag = block.get_tag(0x01)
     creator_tag = pydicom.tag.Tag(priv_tag.group, priv_tag.element >> 8)
 
-    anonymised = anonymise_dicom.anonymise_image(dataset, use_case="Standard")
+    anonymised = anonymise_dicom.anonymise_image(dataset, use_case="Standard",spacy_model_name="en_core_web_sm")
 
     assert str(anonymised[creator_tag].value) == "SIEMENS CSA HEADER"
     # The block's data elements are still scanned and scrubbed.
@@ -221,9 +223,19 @@ def test_structural_cs_values_untouched():
         score_threshold=0.5,
         gliner_pii=None,
         use_case="Standard",
+        spacy_model_name="en_core_web_sm"
     )
     assert list(anonymised_dataset.ImageType) == ["ORIGINAL", "PRIMARY", "M", "ND"]
     assert anonymised_dataset.Modality == "CT"
+
+
+@pytest.fixture(scope="module")
+def presidio_analyser():
+    """The default-model analyser, built once for the whole module.
+
+    Otherwise each build keeps ~0.6 GB alive between tests.
+    """
+    return anonymise_dicom._build_presidio_analyser(0.5)
 
 
 TEST_STRINGS_PII = ["John Doe",
@@ -233,8 +245,8 @@ TEST_STRINGS_PII = ["John Doe",
                     "01/01/1980",
                     "F", "M", "19430617", "076Y"]
 @pytest.mark.parametrize("test_string", TEST_STRINGS_PII)
-def test_presidio_regex_sensitive(test_string: str):
-    analyser = anonymise_dicom._build_presidio_analyser(0.5)
+def test_presidio_regex_sensitive(test_string: str, presidio_analyser):
+    analyser = presidio_analyser
     anonymizer = AnonymizerEngine()
     analyzer_results = analyser.analyze(
                     text=test_string, language="en", score_threshold=0.5
@@ -251,8 +263,8 @@ def test_presidio_regex_sensitive(test_string: str):
 
 TEST_STRINGS_CLEAN = ["Not sensitive", "Flat tire", "Most common"]
 @pytest.mark.parametrize("test_string", TEST_STRINGS_CLEAN)
-def test_presidio_regex_clean(test_string: str):
-    analyser = anonymise_dicom._build_presidio_analyser(0.5)
+def test_presidio_regex_clean(test_string: str, presidio_analyser):
+    analyser = presidio_analyser
     anonymizer = AnonymizerEngine()
     analyzer_results = analyser.analyze(
                     text=test_string, language="en", score_threshold=0.5
@@ -276,7 +288,8 @@ def test_anonymise_image():
                                                          image_redactor=None,
                                                          score_threshold=0.5,
                                                          gliner_pii=None,
-                                                         use_case="Standard")
+                                                         use_case="Standard",
+                                                         spacy_model_name="en_core_web_sm")
     assert anonymised_dataset.PatientName == PersonName('XXXX')
     #assert anonymised_dataset[0x0010, 0x0040].value != 'XXXX'  # Sex unchanged
     if anonymised_dataset[0x0010, 0x0030].value != '':
@@ -306,6 +319,7 @@ def test_anonymise_ds_recurses_into_sq():
         score_threshold=0.5,
         gliner_pii=None,
         use_case="Standard",
+        spacy_model_name="en_core_web_sm"
     )
 
     assert anonymised_dataset.PatientName == PersonName("XXXX")
@@ -335,6 +349,7 @@ def test_anonymise_image_ps3_15_use_case():
         score_threshold=0.5,
         gliner_pii=None,
         use_case="PS3.15",
+        spacy_model_name="en_core_web_sm"
     )
     assert str(anonymised_dataset.PatientName) == ""  # Z
     assert anonymised_dataset.PatientBirthDate == ""  # Z
@@ -368,6 +383,7 @@ def test_anonymise_image_ps3_15_retain_patient_characteristics():
         score_threshold=0.5,
         gliner_pii=None,
         use_case="PS3.15_Rtn. Pat.",
+        spacy_model_name="en_core_web_sm"
     )
     # Patient characteristics retained.
     assert anonymised_dataset.PatientAge == "076Y"
@@ -398,7 +414,7 @@ def test_anonymise_image_scan_private_keeps_and_scrubs_private():
     creator_tag = pydicom.tag.Tag(priv_tag.group, priv_tag.element >> 8)
 
     anonymised = anonymise_dicom.anonymise_image(
-        dataset, use_case="dicom_default_scan_private"
+        dataset, use_case="dicom_default_scan_private", spacy_model_name="en_core_web_sm"
     )
 
     # Standard headers are still de-identified by the Basic Profile.
@@ -415,7 +431,7 @@ def test_anonymise_image_scan_private_keeps_and_scrubs_private():
     plain = pydicom.dcmread(get_testdata_files("CT_small.dcm")[0])
     pblock = plain.private_block(0x0011, "John Doe", create=True)
     pblock.add_new(0x01, "LO", "Jane Smith")
-    plain_anon = anonymise_dicom.anonymise_image(plain, use_case="dicom_default")
+    plain_anon = anonymise_dicom.anonymise_image(plain, use_case="dicom_default", spacy_model_name="en_core_web_sm")
     assert pblock.get_tag(0x01) not in plain_anon
 
 
@@ -443,7 +459,7 @@ def test_ps3_15_scans_sr_text_value(use_case):
     # Profile leaves it alone. It holds the whole narrative report of an SR, so
     # every PS3.15 variant must run the NER pipeline over it rather than let it
     # through untouched.
-    anonymised = anonymise_dicom.anonymise_image(_sr_dataset(), use_case=use_case)
+    anonymised = anonymise_dicom.anonymise_image(_sr_dataset(), use_case=use_case, spacy_model_name="en_core_web_sm")
 
     text_value = str(anonymised[0x0040, 0xA160].value)
     # The report itself is kept -- it is scrubbed, not removed.
@@ -469,5 +485,5 @@ def test_ps3_15_without_free_text_builds_no_analyser(monkeypatch):
 
     dataset = pydicom.dcmread(get_testdata_files("CT_small.dcm")[0])
     assert "TextValue" not in dataset
-    anonymised = anonymise_dicom.anonymise_image(dataset, use_case="dicom_default")
+    anonymised = anonymise_dicom.anonymise_image(dataset, use_case="dicom_default", spacy_model_name="en_core_web_sm")
     assert anonymised.PatientIdentityRemoved == "YES"

--- a/phi_finder/dicom_tools/tests/test_anonymise_dicom.py
+++ b/phi_finder/dicom_tools/tests/test_anonymise_dicom.py
@@ -169,22 +169,32 @@ def test_private_creator_untouched_in_standard_mode():
 
 
 def test_build_engines_plain_ps3_15(monkeypatch):
-    # The plain PS3.15 profile never runs the NER pipeline on headers, so with
-    # destroyed pixels none of the (expensive) engines may be built.
     def _fail(*args, **kwargs):
         raise AssertionError("engine builder should not be called")
 
+    sentinel = object()
     monkeypatch.setattr(anonymise_dicom, "_build_presidio_analyser", _fail)
-    monkeypatch.setattr(anonymise_dicom, "_build_transformer", _fail)
+    monkeypatch.setattr(anonymise_dicom, "_build_transformer", lambda: sentinel)
 
     engines = utils._build_engines(
         use_case="PS3.15",
         score_threshold=0.5,
         spacy_model_name="en_core_web_md",
         destroy_pixels=True,
-        use_transformers=True,
+        use_transformers=False,
     )
     assert engines == (None, None, None, None)
+
+    # GLiNER is built whenever it was asked for, so the free-text scan gets it.
+    analyser, anonymizer, image_redactor, gliner_pii = utils._build_engines(
+        use_case="PS3.15",
+        score_threshold=0.5,
+        spacy_model_name="en_core_web_md",
+        destroy_pixels=True,
+        use_transformers=True,
+    )
+    assert (analyser, anonymizer, image_redactor) == (None, None, None)
+    assert gliner_pii is sentinel
 
 
 def test_structural_cs_values_untouched():
@@ -395,3 +405,58 @@ def test_anonymise_image_scan_private_keeps_and_scrubs_private():
     pblock.add_new(0x01, "LO", "Jane Smith")
     plain_anon = anonymise_dicom.anonymise_image(plain, use_case="dicom_default")
     assert pblock.get_tag(0x01) not in plain_anon
+
+
+SR_REPORT_TEXT = (
+    " CT BRAIN - CLINICAL DATA Right facial droop, reported by Dr Emily Watson "
+    "of Royal Melbourne Hospital on 04/03/2019. Patient John Smith, phone "
+    "0412 345 678. TECHNIQUE Non-contrast axial images were acquired."
+)
+
+
+def _sr_dataset(text: str = SR_REPORT_TEXT) -> pydicom.dataset.Dataset:
+    """Builds a minimal SR that carries its report in Text Value (0040,A160)."""
+    dataset = pydicom.dcmread(get_testdata_files("CT_small.dcm")[0])
+    dataset.Modality = "SR"
+    dataset.ValueType = "CONTAINER"
+    dataset.TextValue = text
+    return dataset
+
+
+@pytest.mark.parametrize(
+    "use_case", ["dicom_default", "dicom_retain_patient", "dicom_retain_patient_scan_private"]
+)
+def test_ps3_15_scans_sr_text_value(use_case):
+    # Text Value (0040,A160) has no PS3.15 Table E.1-1 action, so the Basic
+    # Profile leaves it alone. It holds the whole narrative report of an SR, so
+    # every PS3.15 variant must run the NER pipeline over it rather than let it
+    # through untouched.
+    anonymised = anonymise_dicom.anonymise_image(_sr_dataset(), use_case=use_case)
+
+    text_value = str(anonymised[0x0040, 0xA160].value)
+    # The report itself is kept -- it is scrubbed, not removed.
+    assert 0x0040A160 in anonymised
+    assert "Non-contrast axial images were acquired." in text_value
+    # ...but its PHI is gone.
+    assert "John Smith" not in text_value
+    assert "Emily Watson" not in text_value
+    assert "Royal Melbourne Hospital" not in text_value
+    assert "0412 345 678" not in text_value
+    assert "04/03/2019" not in text_value
+    assert "XXXX" in text_value
+    # The change is recorded in the audit block like any other redacted header.
+    flagged = json.loads(anonymised[0x0209, 0x1000].value)
+    assert any(header["tag"] == "(0040, a160)" for header in flagged)
+
+
+def test_ps3_15_without_free_text_builds_no_analyser(monkeypatch):
+    def _fail(*args, **kwargs):
+        raise AssertionError("analyser should not be built")
+
+    monkeypatch.setattr(anonymise_dicom, "_build_presidio_analyser", _fail)
+    monkeypatch.setattr(anonymise_dicom, "_ANALYSER_CACHE", {})
+
+    dataset = pydicom.dcmread(get_testdata_files("CT_small.dcm")[0])
+    assert "TextValue" not in dataset
+    anonymised = anonymise_dicom.anonymise_image(dataset, use_case="dicom_default")
+    assert anonymised.PatientIdentityRemoved == "YES"

--- a/phi_finder/dicom_tools/tests/test_anonymise_dicom.py
+++ b/phi_finder/dicom_tools/tests/test_anonymise_dicom.py
@@ -454,7 +454,6 @@ def test_ps3_15_without_free_text_builds_no_analyser(monkeypatch):
         raise AssertionError("analyser should not be built")
 
     monkeypatch.setattr(anonymise_dicom, "_build_presidio_analyser", _fail)
-    monkeypatch.setattr(anonymise_dicom, "_ANALYSER_CACHE", {})
 
     dataset = pydicom.dcmread(get_testdata_files("CT_small.dcm")[0])
     assert "TextValue" not in dataset

--- a/phi_finder/dicom_tools/tests/test_data_row_access.py
+++ b/phi_finder/dicom_tools/tests/test_data_row_access.py
@@ -22,7 +22,7 @@ def test_secondary_capture_resource_is_deidentified(
     utils.deidentify_dicom_files(
         data_row_with_secondary,
         score_threshold=0.5,
-        spacy_model_name="en_core_web_md",
+        spacy_model_name="en_core_web_sm",
         destroy_pixels=True,
         use_transformers=False,
         dry_run=False,
@@ -55,7 +55,7 @@ def test_ingest_anonymised_dicom(data_row: DataRow):
     assert n_scans_before == 6
     utils.deidentify_dicom_files(data_row,
                                  score_threshold=0.5,
-                                 spacy_model_name="en_core_web_md",
+                                 spacy_model_name="en_core_web_sm",
                                  destroy_pixels=True,
                                  use_transformers=False,
                                  dry_run=False)
@@ -72,7 +72,7 @@ def test_ingest_anonymised_dicom(data_row: DataRow):
     # Running again to ensure it does not duplicate entries.
     utils.deidentify_dicom_files(data_row,
                                  score_threshold=0.5,
-                                 spacy_model_name="en_core_web_md",
+                                 spacy_model_name="en_core_web_sm",
                                  destroy_pixels=True,
                                  use_transformers=False,
                                  dry_run=False)
@@ -86,7 +86,7 @@ def test_dry_run(data_row: DataRow):
     assert n_scans_before == 6
     utils.deidentify_dicom_files(data_row,
                                  score_threshold=0.5,
-                                 spacy_model_name="en_core_web_md",
+                                 spacy_model_name="en_core_web_sm",
                                  destroy_pixels=True,
                                  use_transformers=False,
                                  dry_run=True)
@@ -118,7 +118,7 @@ def test_pipeline_generates_report(data_row: DataRow):
     """deidentify_dicom_files uploads one session report, and re-runs re-use it."""
     utils.deidentify_dicom_files(data_row,
                                  score_threshold=0.5,
-                                 spacy_model_name="en_core_web_md",
+                                 spacy_model_name="en_core_web_sm",
                                  destroy_pixels=True,
                                  use_transformers=False,
                                  dry_run=False)
@@ -141,7 +141,7 @@ def test_pipeline_generates_report(data_row: DataRow):
     # Re-running the pipeline re-uses the report entry rather than duplicating it.
     utils.deidentify_dicom_files(data_row,
                                  score_threshold=0.5,
-                                 spacy_model_name="en_core_web_md",
+                                 spacy_model_name="en_core_web_sm",
                                  destroy_pixels=True,
                                  use_transformers=False,
                                  dry_run=False)
@@ -152,7 +152,7 @@ def test_dry_run_generates_no_report(data_row: DataRow):
     """A dry-run anonymises nothing, so no report entry is created."""
     utils.deidentify_dicom_files(data_row,
                                  score_threshold=0.5,
-                                 spacy_model_name="en_core_web_md",
+                                 spacy_model_name="en_core_web_sm",
                                  destroy_pixels=True,
                                  use_transformers=False,
                                  dry_run=True)

--- a/phi_finder/dicom_tools/tests/test_html_report.py
+++ b/phi_finder/dicom_tools/tests/test_html_report.py
@@ -1,7 +1,8 @@
 import pydicom
+from presidio_analyzer import RecognizerResult
 from pydicom.data import get_testdata_files
 
-from phi_finder.dicom_tools import anonymise_dicom, html_report
+from phi_finder.dicom_tools import anonymise_dicom, html_report, ps3_15
 
 
 def test_render_text_diff_marks_removed_and_inserted():
@@ -234,10 +235,89 @@ def test_build_html_report_lists_and_dedupes_header_names():
     assert "removed the following types" in html
 
 
+def test_build_html_report_splits_findings_by_source():
+    # Headers the PS3.15 action map handled and headers the NER models read are
+    # reported under separate sections, so it is clear which did what.
+    flagged = [
+        {"tag": "(0010,0010)", "name": "Patient's Name",
+         "source": ps3_15.SOURCE_PS3_15},
+        {"tag": "(0008,0080)", "name": "Institution Name",
+         "source": ps3_15.SOURCE_PS3_15},
+        {"tag": "(0040,A160)", "name": "Text Value",
+         "source": anonymise_dicom.SOURCE_NER},
+    ]
+    html = html_report.build_html_report(flagged, n_images=1)
+
+    assert "Removed by the DICOM PS3.15 profile" in html
+    assert "Found by the text-scanning models" in html
+    # Each name is listed once, under its own section.
+    assert html.count("<li>") == 3
+    ps3_section = html.index("Removed by the DICOM PS3.15 profile")
+    ner_section = html.index("Found by the text-scanning models")
+    assert ps3_section < html.index("Institution Name") < ner_section
+    assert ner_section < html.index("Text Value")
+
+
+def test_build_html_report_omits_empty_finding_sections():
+    # A run with only one kind of finding shows only that section.
+    flagged = [{"tag": "(0040,A160)", "name": "Text Value",
+                "source": anonymise_dicom.SOURCE_NER}]
+    html = html_report.build_html_report(flagged, n_images=1)
+
+    assert "Found by the text-scanning models" in html
+    assert "Removed by the DICOM PS3.15 profile" not in html
+
+
+def test_build_html_report_handles_headers_without_source():
+    # Files anonymised before provenance was recorded still render, in a single
+    # unlabelled section using the original wording.
+    flagged = [{"tag": "(0010,0010)", "name": "Patient's Name"}]
+    html = html_report.build_html_report(flagged, n_images=1)
+
+    assert "removed the following types" in html
+    assert "Removed by the DICOM PS3.15 profile" not in html
+    assert "Found by the text-scanning models" not in html
+    assert html.count("<li>") == 1
+
+
+def test_build_html_report_no_findings_message_unchanged():
+    html = html_report.build_html_report([], n_images=1)
+    assert "found no personal or health information" in html
+    assert "<li>" not in html
+
+
+def test_flagged_headers_record_their_source(monkeypatch):
+    # anonymise_image stamps each record so the report can group them: the
+    # PS3.15 profile handles the standard headers, and the NER models read the
+    # free-text ones the profile has no action for.
+    # A stub analyser stands in for Presidio: this file is the model-free tier,
+    # and a real one would load a full spaCy pipeline just to find one name.
+    class _StubAnalyser:
+        def analyze(self, text, **kwargs):
+            start = text.find("John Smith")
+            if start < 0:
+                return []
+            return [RecognizerResult("PERSON", start, start + len("John Smith"), 0.9)]
+
+    monkeypatch.setattr(
+        anonymise_dicom, "_build_presidio_analyser",
+        lambda score_threshold, spacy_model_name: _StubAnalyser(),
+    )
+
+    ds = pydicom.dcmread(get_testdata_files("CT_small.dcm")[0])
+    ds.add_new(0x0040A160, "UT", "CT BRAIN. Reported by Dr John Smith today.")
+    anonymised = anonymise_dicom.anonymise_image(ds, use_case="dicom_default", spacy_model_name="en_core_web_sm")
+
+    headers = html_report.read_flagged_headers(anonymised)
+    sources = {h["name"]: h["source"] for h in headers}
+    assert sources["Patient's Name"] == ps3_15.SOURCE_PS3_15
+    assert sources["Text Value"] == anonymise_dicom.SOURCE_NER
+
+
 def test_read_flagged_headers_round_trip():
     # anonymise_image records the flagged headers; read_flagged_headers reads them.
     ds = pydicom.dcmread(get_testdata_files("CT_small.dcm")[0])
-    anonymised = anonymise_dicom.anonymise_image(ds, use_case="dicom_default")
+    anonymised = anonymise_dicom.anonymise_image(ds, use_case="dicom_default", spacy_model_name="en_core_web_sm")
     headers = html_report.read_flagged_headers(anonymised)
     assert isinstance(headers, list)
     assert all("name" in h and "tag" in h for h in headers)

--- a/phi_finder/dicom_tools/tests/test_html_report.py
+++ b/phi_finder/dicom_tools/tests/test_html_report.py
@@ -77,6 +77,115 @@ def test_collect_note_diffs_reaches_into_sequences():
     assert diffs[0]["original"] == note
 
 
+def test_collect_note_diffs_labels_nested_location():
+    # A nested note is reported with its full path, not just its element name.
+    ds = pydicom.Dataset()
+    item = pydicom.Dataset()
+    note = "A" * (html_report._CLINICAL_NOTE_MIN_LENGTH + 3)
+    item.add_new(0x001021B0, "LT", note)
+    ds.add_new(0x00081115, "SQ", pydicom.Sequence([item]))
+
+    snapshot = html_report.snapshot_long_text(ds)
+    ds[0x00081115].value[0][0x001021B0].value = "XXXX"
+    diffs = html_report.collect_note_diffs(snapshot, ds)
+
+    assert diffs[0]["location"] == (
+        "Referenced Series Sequence [0] > Additional Patient History"
+    )
+    assert diffs[0]["removed"] is False
+
+
+def test_collect_note_diffs_flags_removed_element():
+    # A note that vanished with its enclosing sequence is flagged as removed,
+    # not reported as an in-place redaction that happened to blank everything.
+    ds = pydicom.Dataset()
+    item = pydicom.Dataset()
+    note = "B" * (html_report._CLINICAL_NOTE_MIN_LENGTH + 3)
+    item.add_new(0x001021B0, "LT", note)
+    ds.add_new(0x00081115, "SQ", pydicom.Sequence([item]))
+
+    snapshot = html_report.snapshot_long_text(ds)
+    ds[0x00081115].value = pydicom.Sequence([])  # the PS3.15 "D" action
+    diffs = html_report.collect_note_diffs(snapshot, ds)
+
+    assert len(diffs) == 1
+    assert diffs[0]["removed"] is True
+    assert diffs[0]["redacted"] == ""
+
+
+def test_collect_note_diffs_separates_duplicate_note_copies():
+    # Regression: an SR carrying the same text at the root and inside Content
+    # Sequence must report both copies separately -- the nested one removed
+    # with the sequence, the root one redacted in place.
+    ds = pydicom.Dataset()
+    note = "CT BRAIN. Patient John Smith, 82 year old male, presented today."
+    inner = pydicom.Dataset()
+    inner.add_new(0x0040A160, "UT", note)
+    outer = pydicom.Dataset()
+    outer.add_new(0x0040A730, "SQ", pydicom.Sequence([inner]))
+    ds.add_new(0x0040A160, "UT", note)
+    ds.add_new(0x0040A730, "SQ", pydicom.Sequence([outer]))
+
+    snapshot = html_report.snapshot_long_text(ds)
+    ds[0x0040A730].value = pydicom.Sequence([])  # profile empties the sequence
+    ds[0x0040A160].value = "CT BRAIN. Patient XXXX, XXXX, presented today."
+    diffs = html_report.collect_note_diffs(snapshot, ds)
+
+    by_location = {d["location"]: d for d in diffs}
+    assert set(by_location) == {
+        "Text Value",
+        "Content Sequence [0] > Content Sequence [0] > Text Value",
+    }
+    assert by_location["Text Value"]["removed"] is False
+    assert "John Smith" not in by_location["Text Value"]["redacted"]
+    nested = by_location["Content Sequence [0] > Content Sequence [0] > Text Value"]
+    assert nested["removed"] is True
+
+
+def test_build_html_report_marks_removed_and_redacted_distinctly():
+    diffs = [
+        {
+            "name": "Text Value",
+            "location": "Text Value",
+            "original": "Patient John Smith presented with a headache today.",
+            "redacted": "Patient XXXX presented with a headache today.",
+            "removed": False,
+        },
+        {
+            "name": "Text Value",
+            "location": "Content Sequence [4] > Text Value",
+            "original": "Patient John Smith presented with a headache today.",
+            "redacted": "",
+            "removed": True,
+        },
+    ]
+    html = html_report.build_html_report([], n_images=1, note_diffs=diffs)
+
+    # Both copies are shown, told apart by location rather than by name alone.
+    assert "Content Sequence [4] &gt; Text Value" in html
+    assert "removed entirely" in html
+    assert "redacted in place" in html
+    # The removed one is not rendered as a word-level redaction.
+    assert html.count("<ins>XXXX</ins>") == 1
+
+
+def test_build_html_report_dedupes_per_location_not_per_name():
+    # Same name, different place in the tree: both must survive de-duplication.
+    base = {
+        "name": "Text Value",
+        "original": "Patient John Smith presented with a headache today.",
+        "redacted": "",
+        "removed": True,
+    }
+    diffs = [
+        {**base, "location": "Content Sequence [1] > Text Value"},
+        {**base, "location": "Content Sequence [4] > Text Value"},
+        {**base, "location": "Content Sequence [4] > Text Value"},  # true duplicate
+    ]
+    html = html_report.build_html_report([], n_images=1, note_diffs=diffs)
+    assert html.count("<h3>") == 2
+
+
 def test_build_html_report_includes_note_diff():
     diffs = [
         {

--- a/phi_finder/dicom_tools/utils.py
+++ b/phi_finder/dicom_tools/utils.py
@@ -51,8 +51,8 @@ def _build_engines(use_case: str,
     """Builds the engines deidentify_dicom_files needs for a given use case.
 
     In the PS3.15 use cases the standard headers are handled by the basic
-    profile. The NER engines (Presidio and GLiNER) are only needed when the 
-    full NER pipeline runs on the headers, or for the "..._scan_private" variants.
+    profile. The NER models (Presidio and GLiNER) are needed for the "..._scan_private" variants, 
+    and for the free-text attributes the profile has no action for (``_NER_SCANNED_TAGS``).
     Presidio also redacts burned-in pixel PHI (if destroy_pixels=False).
 
     Parameters
@@ -79,7 +79,7 @@ def _build_engines(use_case: str,
         use case does not need it.
     """
     ps3_15_mode = ps3_15.is_ps3_15_use_case(use_case)
-    ner_needed = not ps3_15_mode or ps3_15.scan_private_headers(use_case)
+    ner_needed = not ps3_15_mode or ps3_15.scan_private_headers(use_case) or bool(anonymise_dicom._NER_SCANNED_TAGS)
     if ner_needed or destroy_pixels is False:
         analyser = anonymise_dicom._build_presidio_analyser(score_threshold, spacy_model_name)
     else:
@@ -92,17 +92,13 @@ def _build_engines(use_case: str,
         )
     else:
         image_redactor = None
-    # GLiNER is built whenever the caller asked for it: even a PS3.15 use case
-    # that leaves the standard headers to the profile runs the NER pipeline over
-    # the free-text attributes the profile has no action for (e.g. SR Text
-    # Value), and those are exactly the long values GLiNER is there to catch.
     gliner_pii = anonymise_dicom._build_transformer() if use_transformers else None
     return analyser, anonymizer, image_redactor, gliner_pii
 
 
 def deidentify_dicom_files(data_row: DataRow,
                            score_threshold: float=0.5,
-                           spacy_model_name: str="en_core_web_md",
+                           spacy_model_name: str="en_core_web_lg",
                            destroy_pixels: bool=True,
                            use_transformers: bool=False,
                            dry_run: bool=False,
@@ -123,7 +119,7 @@ def deidentify_dicom_files(data_row: DataRow,
         The score threshold for entity recognition. Entities with a score below this
         threshold will not be considered for anonymisation.
 
-    spacy_model_name : str, optional (default "en_core_web_md")
+    spacy_model_name : str, optional (default "en_core_web_lg")
         The name of the SpaCy model to use for NLP processing.
         Other options include "en_core_web_sm" and "en_core_web_lg".
     
@@ -215,13 +211,16 @@ def deidentify_dicom_files(data_row: DataRow,
                 # Snapshot the long free-text fields before anonymise_image
                 # mutates the dataset in place, so we can diff them afterwards.
                 note_snapshot = html_report.snapshot_long_text(dcm)
-                anonymised_dcm = anonymise_dicom.anonymise_image(dcm,
-                                                                 analyser=analyser,
-                                                                 anonymizer=anonymizer,
-                                                                 image_redactor=image_redactor,
-                                                                 score_threshold=score_threshold,
-                                                                 gliner_pii=gliner_pii,
-                                                                 use_case=use_case)
+                anonymised_dcm = anonymise_dicom.anonymise_image(
+                    dcm,
+                    analyser=analyser,
+                    anonymizer=anonymizer,
+                    image_redactor=image_redactor,
+                    score_threshold=score_threshold,
+                    gliner_pii=gliner_pii,
+                    use_case=use_case,
+                    spacy_model_name=spacy_model_name,
+                )
                 report_headers.extend(html_report.read_flagged_headers(anonymised_dcm))
                 note_diffs.extend(html_report.collect_note_diffs(note_snapshot, anonymised_dcm))
                 n_images += 1

--- a/phi_finder/dicom_tools/utils.py
+++ b/phi_finder/dicom_tools/utils.py
@@ -70,8 +70,7 @@ def _build_engines(use_case: str,
         If True, pixel data is destroyed, so no image redactor is needed.
 
     use_transformers : bool
-        If True, GLiNER is used on top of Presidio wherever the NER pipeline
-        runs.
+        If True, GLiNER is used on top of Presidio wherever the NER pipeline runs.
 
     Returns
     -------
@@ -93,10 +92,11 @@ def _build_engines(use_case: str,
         )
     else:
         image_redactor = None
-    if use_transformers and ner_needed:
-        gliner_pii = anonymise_dicom._build_transformer()
-    else:
-        gliner_pii = None
+    # GLiNER is built whenever the caller asked for it: even a PS3.15 use case
+    # that leaves the standard headers to the profile runs the NER pipeline over
+    # the free-text attributes the profile has no action for (e.g. SR Text
+    # Value), and those are exactly the long values GLiNER is there to catch.
+    gliner_pii = anonymise_dicom._build_transformer() if use_transformers else None
     return analyser, anonymizer, image_redactor, gliner_pii
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "phi-finder"
 description = "Collection of tools to check uploaded scans and records for identifiable data."
 readme = "README.md"
-version = "0.1.16"
+version = "0.1.17"
 requires-python = ">=3.11,<3.13"
 dependencies = ["typing_extensions >=4.6.3; python_version < '4.0'",
                 "numpy==1.26.4",


### PR DESCRIPTION
- Making sure tag (0x0040, 0xA160), which contains free text reports, is always checked by the NER models.
- The html report now tells is a given header was modified by NER models or if it is listed in some PS3.15 guidelines.
- Updated Readme.md with example about how to generate the html report.
- Unit tests use Spacy en_core_web_sm instead of en_core_web_md to speed up tests a bit.